### PR TITLE
Fixes for Rust edition 2021 - 'missing dyn' and 'dyn_drop'

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,3 +2,4 @@ Jonathan Reem
 Steven Fackler
 Alexander Regueiro
 Philip Peterson
+Francis Lalonde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ authors = [
   "Jonathan Reem <jonathan.reem@gmail.com>",
   "Steven Fackler <sfackler@gmail.com>",
   "Alexander Regueiro <alexreg@me.com>",
-  "Philip Peterson <philip.c.peterson@gmail.com>"
+  "Philip Peterson <philip.c.peterson@gmail.com>",
+  "Francis Lalonde <fralalonde@gmail.com>",
 ]
+edition = "2021"
 repository = "https://github.com/philip-peterson/destructure_traitobject.git"
 description = "Unsafe helpers for working with raw trait objects. (Forked from traitobject)"
 readme = "README.md"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,78 +1,83 @@
-use Trait;
+use std::any::Any;
+use std::borrow::{Borrow, BorrowMut};
+use std::error::Error;
+use std::{fmt, hash, io};
 
-unsafe impl Trait for Send { }
-unsafe impl Trait for Sync { }
-unsafe impl Trait for Send + Sync { }
-unsafe impl Trait for ::std::any::Any + Send { }
-unsafe impl Trait for ::std::any::Any + Sync { }
-unsafe impl Trait for ::std::any::Any + Send + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::borrow::Borrow<T> + Send { }
-unsafe impl<T: ?Sized> Trait for ::std::borrow::Borrow<T> + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::borrow::Borrow<T> + Send + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::borrow::BorrowMut<T> + Send { }
-unsafe impl<T: ?Sized> Trait for ::std::borrow::BorrowMut<T> + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::borrow::BorrowMut<T> + Send + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::convert::AsMut<T> + Send { }
-unsafe impl<T: ?Sized> Trait for ::std::convert::AsMut<T> + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::convert::AsMut<T> + Send + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::convert::AsRef<T> + Send { }
-unsafe impl<T: ?Sized> Trait for ::std::convert::AsRef<T> + Sync { }
-unsafe impl<T: ?Sized> Trait for ::std::convert::AsRef<T> + Send + Sync { }
-unsafe impl Trait for ::std::error::Error + Send { }
-unsafe impl Trait for ::std::error::Error + Sync { }
-unsafe impl Trait for ::std::error::Error + Send + Sync { }
-unsafe impl Trait for ::std::fmt::Binary + Send { }
-unsafe impl Trait for ::std::fmt::Binary + Sync { }
-unsafe impl Trait for ::std::fmt::Binary + Send + Sync { }
-unsafe impl Trait for ::std::fmt::Debug + Send { }
-unsafe impl Trait for ::std::fmt::Debug + Sync { }
-unsafe impl Trait for ::std::fmt::Debug + Send + Sync { }
-unsafe impl Trait for ::std::fmt::Display + Send { }
-unsafe impl Trait for ::std::fmt::Display + Sync { }
-unsafe impl Trait for ::std::fmt::Display + Send + Sync { }
-unsafe impl Trait for ::std::fmt::LowerExp + Send { }
-unsafe impl Trait for ::std::fmt::LowerExp + Sync { }
-unsafe impl Trait for ::std::fmt::LowerExp + Send + Sync { }
-unsafe impl Trait for ::std::fmt::LowerHex + Send { }
-unsafe impl Trait for ::std::fmt::LowerHex + Sync { }
-unsafe impl Trait for ::std::fmt::LowerHex + Send + Sync { }
-unsafe impl Trait for ::std::fmt::Octal + Send { }
-unsafe impl Trait for ::std::fmt::Octal + Sync { }
-unsafe impl Trait for ::std::fmt::Octal + Send + Sync { }
-unsafe impl Trait for ::std::fmt::Pointer + Send { }
-unsafe impl Trait for ::std::fmt::Pointer + Sync { }
-unsafe impl Trait for ::std::fmt::Pointer + Send + Sync { }
-unsafe impl Trait for ::std::fmt::UpperExp + Send { }
-unsafe impl Trait for ::std::fmt::UpperExp + Sync { }
-unsafe impl Trait for ::std::fmt::UpperExp + Send + Sync { }
-unsafe impl Trait for ::std::fmt::UpperHex + Send { }
-unsafe impl Trait for ::std::fmt::UpperHex + Sync { }
-unsafe impl Trait for ::std::fmt::UpperHex + Send + Sync { }
-unsafe impl Trait for ::std::fmt::Write + Send { }
-unsafe impl Trait for ::std::fmt::Write + Sync { }
-unsafe impl Trait for ::std::fmt::Write + Send + Sync { }
-unsafe impl Trait for ::std::hash::Hasher + Send { }
-unsafe impl Trait for ::std::hash::Hasher + Sync { }
-unsafe impl Trait for ::std::hash::Hasher + Send + Sync { }
-unsafe impl Trait for ::std::io::BufRead + Send { }
-unsafe impl Trait for ::std::io::BufRead + Sync { }
-unsafe impl Trait for ::std::io::BufRead + Send + Sync { }
-unsafe impl Trait for ::std::io::Read + Send { }
-unsafe impl Trait for ::std::io::Read + Sync { }
-unsafe impl Trait for ::std::io::Read + Send + Sync { }
-unsafe impl Trait for ::std::io::Seek + Send { }
-unsafe impl Trait for ::std::io::Seek + Sync { }
-unsafe impl Trait for ::std::io::Seek + Send + Sync { }
-unsafe impl Trait for ::std::io::Write + Send { }
-unsafe impl Trait for ::std::io::Write + Sync { }
-unsafe impl Trait for ::std::io::Write + Send + Sync { }
-unsafe impl<T, I> Trait for ::std::iter::IntoIterator<IntoIter = I, Item = T> { }
-unsafe impl<T> Trait for ::std::iter::Iterator<Item = T> + Send { }
-unsafe impl<T> Trait for ::std::iter::Iterator<Item = T> + Sync { }
-unsafe impl<T> Trait for ::std::iter::Iterator<Item = T> + Send + Sync { }
-unsafe impl Trait for ::std::ops::Drop + Send { }
-unsafe impl Trait for ::std::ops::Drop + Sync { }
-unsafe impl Trait for ::std::ops::Drop + Send + Sync { }
-unsafe impl Trait for ::std::string::ToString + Send { }
-unsafe impl Trait for ::std::string::ToString + Sync { }
-unsafe impl Trait for ::std::string::ToString + Send + Sync { }
+use crate::Trait;
+
+unsafe impl Trait for dyn Send { }
+unsafe impl Trait for dyn Sync { }
+unsafe impl Trait for dyn Send + Sync { }
+unsafe impl Trait for dyn Any + Send { }
+unsafe impl Trait for dyn Any + Sync { }
+unsafe impl Trait for dyn Any + Send + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn Borrow<T> + Send { }
+unsafe impl<T: ?Sized> Trait for dyn Borrow<T> + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn Borrow<T> + Send + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn BorrowMut<T> + Send { }
+unsafe impl<T: ?Sized> Trait for dyn BorrowMut<T> + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn BorrowMut<T> + Send + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn AsMut<T> + Send { }
+unsafe impl<T: ?Sized> Trait for dyn AsMut<T> + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn AsMut<T> + Send + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn AsRef<T> + Send { }
+unsafe impl<T: ?Sized> Trait for dyn AsRef<T> + Sync { }
+unsafe impl<T: ?Sized> Trait for dyn AsRef<T> + Send + Sync { }
+unsafe impl Trait for dyn Error + Send { }
+unsafe impl Trait for dyn Error + Sync { }
+unsafe impl Trait for dyn Error + Send + Sync { }
+unsafe impl Trait for dyn fmt::Binary + Send { }
+unsafe impl Trait for dyn fmt::Binary + Sync { }
+unsafe impl Trait for dyn fmt::Binary + Send + Sync { }
+unsafe impl Trait for dyn fmt::Debug + Send { }
+unsafe impl Trait for dyn fmt::Debug + Sync { }
+unsafe impl Trait for dyn fmt::Debug + Send + Sync { }
+unsafe impl Trait for dyn fmt::Display + Send { }
+unsafe impl Trait for dyn fmt::Display + Sync { }
+unsafe impl Trait for dyn fmt::Display + Send + Sync { }
+unsafe impl Trait for dyn fmt::LowerExp + Send { }
+unsafe impl Trait for dyn fmt::LowerExp + Sync { }
+unsafe impl Trait for dyn fmt::LowerExp + Send + Sync { }
+unsafe impl Trait for dyn fmt::LowerHex + Send { }
+unsafe impl Trait for dyn fmt::LowerHex + Sync { }
+unsafe impl Trait for dyn fmt::LowerHex + Send + Sync { }
+unsafe impl Trait for dyn fmt::Octal + Send { }
+unsafe impl Trait for dyn fmt::Octal + Sync { }
+unsafe impl Trait for dyn fmt::Octal + Send + Sync { }
+unsafe impl Trait for dyn fmt::Pointer + Send { }
+unsafe impl Trait for dyn fmt::Pointer + Sync { }
+unsafe impl Trait for dyn fmt::Pointer + Send + Sync { }
+unsafe impl Trait for dyn fmt::UpperExp + Send { }
+unsafe impl Trait for dyn fmt::UpperExp + Sync { }
+unsafe impl Trait for dyn fmt::UpperExp + Send + Sync { }
+unsafe impl Trait for dyn fmt::UpperHex + Send { }
+unsafe impl Trait for dyn fmt::UpperHex + Sync { }
+unsafe impl Trait for dyn fmt::UpperHex + Send + Sync { }
+unsafe impl Trait for dyn fmt::Write + Send { }
+unsafe impl Trait for dyn fmt::Write + Sync { }
+unsafe impl Trait for dyn fmt::Write + Send + Sync { }
+unsafe impl Trait for dyn hash::Hasher + Send { }
+unsafe impl Trait for dyn hash::Hasher + Sync { }
+unsafe impl Trait for dyn hash::Hasher + Send + Sync { }
+unsafe impl Trait for dyn io::BufRead + Send { }
+unsafe impl Trait for dyn io::BufRead + Sync { }
+unsafe impl Trait for dyn io::BufRead + Send + Sync { }
+unsafe impl Trait for dyn io::Read + Send { }
+unsafe impl Trait for dyn io::Read + Sync { }
+unsafe impl Trait for dyn io::Read + Send + Sync { }
+unsafe impl Trait for dyn io::Seek + Send { }
+unsafe impl Trait for dyn io::Seek + Sync { }
+unsafe impl Trait for dyn io::Seek + Send + Sync { }
+unsafe impl Trait for dyn io::Write + Send { }
+unsafe impl Trait for dyn io::Write + Sync { }
+unsafe impl Trait for dyn io::Write + Send + Sync { }
+unsafe impl<T, I> Trait for dyn IntoIterator<IntoIter = I, Item = T> { }
+unsafe impl<T> Trait for dyn Iterator<Item = T> + Send { }
+unsafe impl<T> Trait for dyn Iterator<Item = T> + Sync { }
+unsafe impl<T> Trait for dyn Iterator<Item = T> + Send + Sync { }
+unsafe impl Trait for dyn Drop + Send { }
+unsafe impl Trait for dyn Drop + Sync { }
+unsafe impl Trait for dyn Drop + Send + Sync { }
+unsafe impl Trait for dyn ToString + Send { }
+unsafe impl Trait for dyn ToString + Sync { }
+unsafe impl Trait for dyn ToString + Send + Sync { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(test, deny(warnings))]
 #![deny(missing_docs)]
+#![allow(dyn_drop)]
 
 //! # traitobject
 //!
@@ -21,7 +22,7 @@ pub unsafe fn data_mut<T: ?Sized>(val: *mut T) -> *mut () {
 
 #[test]
 fn test_simple() {
-    let x = &7 as &Send;
+    let x = &7 as &dyn Send;
     unsafe { assert!(&7 == std::mem::transmute::<_, &i32>(data(x))) };
 }
 


### PR DESCRIPTION
Fixes for warnings generated by when building with the latest Rust (rustc 1.67.1).

Upstreamed from https://github.com/fralalonde/traitobject_patch for easier syncing with any future changes to `destructure_traitobject`
